### PR TITLE
checking currentValue != null rather than hasInitialValue flag

### DIFF
--- a/lib/src/stream_property.dart
+++ b/lib/src/stream_property.dart
@@ -22,7 +22,7 @@ class _StreamProperty<T> extends _ControllerProperty<T> {
   StreamSubscription<T> listen(void onData(T event), {Function onError, void onDone(), bool cancelOnError}) {
     Stream stream;
 
-    if (_hasInitialValue) {
+    if (_currentValue != null) {
       stream = new EventStream(new Stream.fromIterable([_currentValue])).merge(changes);
     } else {
       stream = changes;


### PR DESCRIPTION
From my debugging a lot of the issues I am hitting seem to stem from StreamProperties that have a current value but the hasInitialValue flag as false. I'm not sure why you have the flag but this change seems to fix some of the problems I am seeing.

What is the purpose of having this flag separate from the currentValue? Under what use cases does it make sense to not return the currentValue in response to `first` etc?
