### PR TITLE
Add type annotations to methods.

### DIFF
--- a/lib/src/event_stream.dart
+++ b/lib/src/event_stream.dart
@@ -95,7 +95,7 @@ class EventStream<T> extends Reactable<T> {
 
   EventStream combine(Stream other, Object combiner(T a, b)) => transform(new Combine(other, combiner));
 
-  EventStream concat(Stream other) => transform(new Concat(other));
+  EventStream concat(Stream other) => transform(new Concat<T>(other));
 
   EventStream concatAll() => transform(new ConcatAll());
 
@@ -114,7 +114,7 @@ class EventStream<T> extends Reactable<T> {
 
   EventStream flatMapLatest(Stream convert(T event)) => transform(new FlatMapLatest(convert));
 
-  EventStream<T> handleError(onError, {bool test(error)}) =>
+  EventStream<T> handleError(Function onError, {bool test(error)}) =>
       new EventStream(super.handleError(onError, test: test));
 
   StreamSubscription<T> listen(void onData(T event), {Function onError, void onDone(), bool cancelOnError}) {
@@ -145,7 +145,7 @@ class EventStream<T> extends Reactable<T> {
 
   EventStream startWith(value) => transform(new StartWith(value));
 
-  EventStream startWithValues(Iterable values) => transform(new StartWith.many(values));
+  EventStream startWithValues(Iterable values) => transform(new StartWith<T>.many(values));
 
   EventStream<T> take(int count) => new EventStream(super.take(count));
 
@@ -163,5 +163,5 @@ class EventStream<T> extends Reactable<T> {
 
   EventStream<T> where(bool test(T event)) => new EventStream(super.where(test));
 
-  EventStream zip(Stream other, Combiner combiner) => transform(new Zip(other, combiner));
+  EventStream zip(Stream other, Combiner combiner) => transform(new Zip<T, dynamic, dynamic>(other, combiner));
 }

--- a/lib/src/property.dart
+++ b/lib/src/property.dart
@@ -18,7 +18,7 @@ class Property<T> extends Reactable<T> {
   /// An [EventStream] that contains the changes of the property.
   ///
   /// The stream will *not* contain an event for the current value of the `Property`.
-  EventStream<T> get changes => new EventStream(_controller.stream);
+  EventStream<T> get changes => new EventStream<T>(_controller.stream);
 
   @override
   bool get isBroadcast => _controller.stream.isBroadcast;
@@ -106,7 +106,7 @@ class Property<T> extends Reactable<T> {
 
   Property combine(Stream other, Object combiner(T a, b)) => transform(new Combine(other, combiner));
 
-  Property concat(Stream other) => transform(new Concat(other));
+  Property concat(Stream other) => transform(new Concat<T>(other));
 
   Property concatAll() => transform(new ConcatAll());
 
@@ -125,7 +125,7 @@ class Property<T> extends Reactable<T> {
 
   Property flatMapLatest(Stream convert(T event)) => transform(new FlatMapLatest(convert));
 
-  Property<T> handleError(onError, {bool test(error)}) =>
+  Property<T> handleError(Function onError, {bool test(error)}) =>
       new Property.fromStream(super.handleError(onError, test: test));
 
   StreamSubscription<T> listen(void onData(T value), {Function onError, void onDone(), bool cancelOnError}) {
@@ -164,7 +164,7 @@ class Property<T> extends Reactable<T> {
 
   Property startWith(value) => transform(new StartWith(value));
 
-  Property startWithValues(Iterable values) => transform(new StartWith.many(values));
+  Property<T> startWithValues(Iterable values) => transform(new StartWith<T>.many(values));
 
   Property<T> take(int count) => new Property.fromStream(super.take(count));
 
@@ -182,7 +182,7 @@ class Property<T> extends Reactable<T> {
 
   Property<T> where(bool test(T event)) => new Property.fromStream(super.where(test));
 
-  Property zip(Stream other, Combiner combiner) => transform(new Zip(other, combiner));
+  Property zip(Stream other, Combiner combiner) => transform(new Zip<T, dynamic, dynamic>(other, combiner));
 
   // Deprecated
 

--- a/lib/src/reactable.dart
+++ b/lib/src/reactable.dart
@@ -288,7 +288,7 @@ abstract class Reactable<T> extends Stream<T> {
   }
 
   @override
-  Reactable<T> handleError(onError, {bool test(error)});
+  Reactable<T> handleError(Function onError, {bool test(error)});
 
   @override
   Reactable map(convert(T event));


### PR DESCRIPTION
@danschultz 

Most of these fixes are related to type signatures being incorrect: dart analyzer doesn't care and assumes `dynamic` for everything that's missing, but `dev_compiler` will outright reject those signatures.

Take a good look and make sure I haven't butchered any of the signatures.

Closes #47 