### PR TITLE
add library dartdocs to the frappe library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Don’t commit the following directories created by pub.
 build/
 packages
+.packages
 .pub/
 
 # Or the files created by dart2js.
@@ -9,6 +10,8 @@ packages
 *.js_
 *.js.deps
 *.js.map
+
+doc/api/
 
 # Include when developing application packages.
 pubspec.lock

--- a/lib/frappe.dart
+++ b/lib/frappe.dart
@@ -1,6 +1,10 @@
+/// A functional reactive programming library for Dart. Frappé extends the
+/// functionality of Dart's streams, and introduces new concepts like properties
+/// / signals.
 library frappe;
 
 import 'dart:async';
+
 import 'package:stream_transformers/stream_transformers.dart';
 
 part 'src/reactable.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,3 +16,4 @@ dev_dependencies:
   browser: ^0.10.0
   grinder: '>=0.7.0 <0.7.1'
   guinness: ^0.1.6
+  unittest: ^0.11.0


### PR DESCRIPTION
Minor updates to the gitignore and pubspec file, and add library dartdocs to the main frappe library.