### PR TITLE
some strong mode changes

### DIFF
--- a/.analysis_options
+++ b/.analysis_options
@@ -1,0 +1,2 @@
+analyzer:
+#  strong-mode: true

--- a/example/auto_complete/index.dart
+++ b/example/auto_complete/index.dart
@@ -1,5 +1,7 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:html';
+
 import 'package:frappe/frappe.dart';
 
 void main() {
@@ -29,13 +31,13 @@ void main() {
 
 EventStream<Iterable<String>> queryTerm(String term) {
   if (term.length > 2) {
-    var params = {
+    Map<String, String> params = {
         "api_key": "9eae05e667b4d5d9fbb75d27622347fe",
         "query": term
     };
 
     var uri = Uri.parse("http://api.themoviedb.org/3/search/movie").replace(queryParameters: params);
-    var results = HttpRequest.getString(uri.toString())
+    Future<Iterable<String>> results = HttpRequest.getString(uri.toString())
         .then((response) => JSON.decode(response))
         .then((json) => json["results"].map((result) => result["original_title"]));
 

--- a/test/event_stream_test.dart
+++ b/test/event_stream_test.dart
@@ -32,11 +32,11 @@ import 'shared/util.dart';
 
 void main() => describe("EventStream", () {
   EventStream<int> stream;
-  StreamController controller;
+  StreamController<int> controller;
 
   beforeEach(() {
     controller = new StreamController();
-    stream = new EventStream(controller.stream);
+    stream = new EventStream<int>(controller.stream);
   });
 
   it("delivers values from the source stream", () {

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -1,6 +1,6 @@
 import 'package:grinder/grinder.dart';
 
-main(args) => grind(args);
+main(List<String> args) => grind(args);
 
 @Task("Analyzes the package for errors or warnings")
 analyze() {
@@ -17,6 +17,4 @@ test() => Tests.runCliTests(testFile: "all_tests.dart");
 
 @DefaultTask()
 @Depends(analyze, test, lint)
-build() {
-
-}
+build() { }


### PR DESCRIPTION
Some very small tweaks as a result of analyzing with strong mode (compiling against DDC). Many of the remaining issues with `frappe` and `stream_transformers` (most visible here: http://dart-atom.github.io/dartlang/entry_dart_results.html) will I think require generic methods.
